### PR TITLE
Allow for custom emitter to emit events to

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -10,14 +10,14 @@ const Path = require('path')
 const internals = {}
 
 const Migrate = function (opt) {
-  emit('info', 'Validating options')()
+  emit('info', 'Validating options', opt)()
   return validateOptions(opt)
-    .then(emit('info', 'Connecting to RethinkDB'))
+    .then(emit('info', 'Connecting to RethinkDB', opt))
     .then(connectToRethink)
     .then(createDbIfInexistent)
-    .then(emit('info', 'Executing Migrations'))
+    .then(emit('info', 'Executing Migrations', opt))
     .then(executeMigration)
-    .then(emit('info', 'Closing connection'))
+    .then(emit('info', 'Closing connection', opt))
     .then(closeConnection)
 }
 
@@ -70,7 +70,8 @@ function validateOptions (options) {
           .description('The port to connect on')
       }))
     }),
-    ssl: Joi.alternatives().try(Joi.object(), Joi.boolean()).default(false).description('Rethinkdb SSL/TLS support')
+    ssl: Joi.alternatives().try(Joi.object(), Joi.boolean()).default(false).description('Rethinkdb SSL/TLS support'),
+    emitter: Joi.any().description('An alternate event emitter on which to emit event')
   }).without('user', 'username').without('password', 'authKey').required()
 
   return new Promise((resolve, reject) => {
@@ -135,7 +136,7 @@ function createDbIfInexistent (options) {
     .then(toArray)
     .then(list => {
       if (list.indexOf(db) < 0) {
-        emit('info', 'Creating db', db)()
+        emit('info', 'Creating db' + db, options)()
         return r.dbCreate(db).run(conn)
       }
     })
@@ -169,7 +170,7 @@ function migrateUp (options) {
   return getLatestMigrationExecuted(options)
     .then(latest => getUnExecutedMigrations(latest, options))
     .then(newerMigrations => runMigrations('up', newerMigrations, options))
-    .then(emit('info', 'Saving metada'))
+    .then(emit('info', 'Saving metada', options))
     .then(executedMigrations => saveExecutedMigrationsMetadata(executedMigrations, options))
     .then(() => options)
 }
@@ -178,7 +179,7 @@ function migrateDown (options) {
   return getExecutedMigrations(options)
     .then(migrations => runMigrations('down', migrations, options))
     .then(migrations => clearMigrationsTable(migrations, options))
-    .then(emit('info', 'Cleared migrations table'))
+    .then(emit('info', 'Cleared migrations table', options))
     .then(() => options)
 }
 
@@ -318,7 +319,7 @@ function runMigrations (direction, migrations, options) {
   const { r, conn } = options
   return migrations.reduce(
     (chain, migration) => chain.then(() => migration.code[direction](r, conn)
-      .then(emit('info', `Executed migration ${migration.name} ${options.op} (file: ${migration.filename}, dir:${Path.relative(options.relativeTo, migration.dir)} )`))),
+      .then(emit('info', `Executed migration ${migration.name} ${options.op} (file: ${migration.filename}, dir:${Path.relative(options.relativeTo, migration.dir)} )`, options))),
     Promise.resolve()
   ).then(() => migrations)
 }
@@ -359,9 +360,12 @@ function closeConnection (options) {
   return conn.close()
 }
 
-function emit (name, data) {
+function emit(name, data, options) {
   return function (arg) {
     internals.emitter.emit(name, data)
+    if (options && options.emitter) {
+      options.emitter.emit(name, data);
+    }
     return arg
   }
 }


### PR DESCRIPTION
This is useful in case of multiple migrate instances that would otherwise
all emit on the same emitter.